### PR TITLE
Allow unbounded logical bounds for beta.tgt and singular beta.sigma

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -1157,6 +1157,9 @@ check.betatgt.lp <- function(data, lpmodel, modelsense, solver) {
   # Solve the linear program
   ans <- do.call(solver, optim.arg)
 
+  if (ans$status == "INF_OR_UNBD") {
+    ans$objval <- ifelse(modelsense == "max", Inf, -Inf)
+  }
   # ---------------- #
   # Step 3: Return result
   # ---------------- #


### PR DESCRIPTION
This branch makes changes to allow 1) logical bounds for beta.tgt to be unbounded, and 2) beta.sigma to be singular (in which case we add a small identity matrix). For the latter, beta.sigma is determined to be singular if its smallest eigenvalue is less than beta.sigma.tol, in which case beta.sigma.eps * diag(nrow(beta.sigma)) is added to beta.sigma to make it positive definite. Both beta.sigma.tol and beta.sigma.eps can be provided by the user, with default values being 1e-08 and 1e-06, respectively. 